### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
   
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,7 +18,6 @@ class ItemsController < ApplicationController
     end
   end
 
-
   private
   def item_params
     params.require(:item).permit( :image, :name, :explain, :category_id, :condition_id, :delivery_charge_id, :prefecture_id, :shipping_day_id, :price ).merge(user_id: current_user.id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,9 +124,9 @@
             <%# //商品が売れていればsold outを表示しましょう %>
             </div>
             <div class="item-info">
-              <h3 class="item-name"><%= @item.name %></h3>
+              <h3 class="item-name"><%= "商品名" %></h3>
               <div class="item-price">
-                <span><%= @item.price %>円<br><%= item.delivery_charge.name %></span>
+                <span><%= "商品価格" %>円<br><%= "配送料負担" %></span>
                 <div class="star-btn">
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class="star-count">0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -112,7 +112,7 @@
           </li>
         <% end %>
       <% else %>
-        <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
         <li class="list">
           <%= link_to "#" do %>
             <div class="item-img-content">
@@ -124,9 +124,9 @@
             <%# //商品が売れていればsold outを表示しましょう %>
             </div>
             <div class="item-info">
-              <h3 class="item-name"><%= "商品名" %></h3>
+              <h3 class="item-name"><%= @item.name %></h3>
               <div class="item-price">
-                <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+                <span><%= @item.price %>円<br><%= item.delivery_charge.name %></span>
                 <div class="star-btn">
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class="star-count">0</span>
@@ -135,7 +135,7 @@
             </div>
           <% end %>
         </li>
-        <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
         <li class="list">
           <%= link_to '#' do %>
             <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -96,7 +96,7 @@
             <%= link_to "#" do %>
               <div class="item-img-content">
                 <%= image_tag item.image, class: "item-img" %>
-                <%# ②「sold out」表示 %>
+                <%# ②「sold out」の表示 %>
               </div>
               <div class="item-info">
                 <h3 class="item-name"><%= item.name %></h3>


### PR DESCRIPTION
## what
商品情報を一覧で見れるように実装した

## why
商品一覧表示機能実装のため

 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/1931bfffd031ba9e919c98c7de009ec0
 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
 https://gyazo.com/3c29e92040a94202a49d146892da0047
 
 ※間違えてmainブランチで作業してしまい、さらに間違えて git reset コマンドなどをしてしまった影響で
 だいぶ見ずらいかもしれませんが何卒よろしくお願いします。